### PR TITLE
chore: release 2025.08.13.10.32

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,13 @@
+### 2025.08.13.10.32
+
+#### @orz/baserow 0.1.3 (patch)
+
+- feat(baserow): Add fields in BaserowFile
+
+#### @orz/determiner 0.1.0 (minor)
+
+- feat(determiner): init package
+
 ### 2025.08.04.11.51
 
 #### @orz/marline 0.1.2 (patch)

--- a/packages/baserow/deno.json
+++ b/packages/baserow/deno.json
@@ -8,5 +8,5 @@
   "tasks": {
     "dev": "deno run --watch mod.ts"
   },
-  "version": "0.1.2"
+  "version": "0.1.3"
 }


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|baserow|0.1.2|0.1.3|patch|
|determiner|0.0.0|0.1.0|minor|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly









---

To make edits to this PR:

```sh
git fetch upstream release-2025-08-13-10-32-26 && git checkout -b release-2025-08-13-10-32-26 upstream/release-2025-08-13-10-32-26
```
